### PR TITLE
Update globalinstall.ps1

### DIFF
--- a/1.0.0-beta7/globalinstall.ps1
+++ b/1.0.0-beta7/globalinstall.ps1
@@ -14,4 +14,5 @@ $webClient.DownloadFile('https://raw.githubusercontent.com/aspnet/Home/dev/dnvm.
 Write-Host "Downloading DNVM.cmd to $dnvmCmdPath"
 $webClient.DownloadFile('https://raw.githubusercontent.com/aspnet/Home/dev/dnvm.cmd', $dnvmCmdPath)
 
+$oldPath = [Environment]::GetEnvironmentVariable("PATH", "MACHINE")
 [Environment]::SetEnvironmentVariable("PATH", "$oldPath;$InstallPath", "MACHINE")


### PR DESCRIPTION
Fixing a bug caused the existing PATH value to be wiped.
Append the $InstallPath to the existing PATH environment variable.
